### PR TITLE
Fix extracting the size of image into variables.

### DIFF
--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -169,8 +169,8 @@ final class ImageHelper
             throw new \RuntimeException('Need GD extension');
         }
 
-        // Get current dimensions
-        list($width, $height, $type) = self::getSizeOfImage($img);
+        // Get current dimensions as variables $width, $height and $type
+        extract(self::getSizeOfImage($img));
 
         // Definitions
         $dstWidth = $newWidth;


### PR DESCRIPTION
This is a small fix for the resize() function on the ImageHelper where it threw errors on call because the list() structure wants integer keys and the getSizeOfImage() method returns an associative array. The fix here has been to use extract, using keys in the list() structure would have worked too but is available only from PHP 7.1 onwards.